### PR TITLE
Code cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,46 +20,29 @@ Your system administrators should be able to provide both of these.
 
 Example configuration (assuming you are allowed to have 12h sessions):
 ```bash
-$ okta-aws-login  --configure --okta-embed-link https://YOURSITE.okta.com/home/amazon_aws/xxxxxxxxxxxxxxxxxxxx/yyy --aws-profile production --default --ecr --session-duration 43200
+$ okta-aws-login configure --okta-embed-link https://YOURSITE.okta.com/home/amazon_aws/xxxxxxxxxxxxxxxxxxxx/yyy --aws-profile production --default --ecr --session-duration 43200
 ```
+
+Run `okta-aws-login configure -h` for description of configuration options.
 
 
 # CLI
 
 ```bash
-$ okta-aws-login -h
-
 Login to AWS via Okta/SAML.
 
-Usage: okta-aws-login ([--configure] [-p|--aws-profile ARG]
-                      [-l|--okta-embed-link ARG] [-d|--default] [-r|--ecr]
-                      [-c|--config-file ARG] [-s|--session-duration ARG] |
-                      [-v|--verbose] [-V|--version] [-l|--list-profiles]
-                      [-u|--user ARG] [-p|--aws-profile ARG] [-r|--region ARG]
+Usage: okta-aws-login ([COMMAND] | [-V|--version] [-v|--verbose] [-u|--user ARG]
+                      [-p|--aws-profile ARG] [-r|--region ARG]
                       [-c|--config-file ARG] [-k|--keep-reloading] ([--no-ecr] |
-                      [--ecr]))
+                      [--ecr]) | [-l|--list-profiles])
   Login to AWS via Okta/SAML (source:
   https://github.com/saksdirect/okta-aws-login) Default config file:
   "/Users/yourhome/.okta-aws-login.json"
 
 Available options:
   -h,--help                Show this help text
-  --configure              Configure AWS profile given an Okta 'embed' link
-  -p,--aws-profile ARG     Name of the associated AWS profile.
-  -l,--okta-embed-link ARG Okta AWS app 'embed' link, ask your Okta
-                           administrator.
-  -d,--default             User this profile by default.
-  -r,--ecr                 Enable Docker login to ECR registry by default.
-  -c,--config-file ARG     Use alternative config
-                           file. (default: "/Users/yourhome/.okta-aws-login.json")
-  -s,--session-duration ARG
-                           STS session duration, seconds. You can provide a
-                           value from 900 seconds (15 minutes) up to the maximum
-                           session duration setting for the role. Please
-                           coordinate with your AWS administrator.
-  -v,--verbose             Be verbose.
   -V,--version             Print version and exit.
-  -l,--list-profiles       List available AWS profiles and exit.
+  -v,--verbose             Be verbose.
   -u,--user ARG            User name.
   -p,--aws-profile ARG     AWS profile. Defaults to value of AWS_PROFILE env
                            var, then to default config entry.
@@ -73,6 +56,10 @@ Available options:
                            config.
   --ecr                    Attempt Docker login to ECR registry, default is in
                            the config.
+  -l,--list-profiles       List available AWS profiles and exit.
+
+Available commands:
+  configure                Configure AWS profile given an Okta 'embed' link
 
 Log in using default AWS profile, you'll be prompted for user name / password: 
 
@@ -89,7 +76,6 @@ Log in with more than one AWS profile:
 Skip ECR login (note that you can set default behavior in the config file) 
 
   $ okta-aws-login --no-ecr --user my-okta-user-name --aws-profile my-aws-profile1
-
 ```
 
 

--- a/install
+++ b/install
@@ -4,7 +4,7 @@
 
 set -e
 
-DL=https://github.com/saksdirect/okta-aws-login/releases/download/v1.1
+DL=https://github.com/saksdirect/okta-aws-login/releases/download/v1.2
 DL_BIN=$DL/okta-aws-login-$(uname -s)-$(uname -m)
 TARGET=/usr/local/bin/okta-aws-login
 

--- a/okta-aws-login.cabal
+++ b/okta-aws-login.cabal
@@ -24,6 +24,7 @@ executable okta-aws-login
                        Args
                        DockerLogin
                        OktaClient
+                       OktaLogin
                        STS
                        Types
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,42 +1,41 @@
-{-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
-{-# LANGUAGE TemplateHaskell    #-}
 
 module Main where
 
 
-import           AWSCredsFile
 import           App
 import           AppConfig
 import           Args
-import           Control.Concurrent
 import           Control.Monad
-import           Control.Monad.IO.Class
-import           Control.Monad.Logger
-import           Control.Monad.Loops
-import qualified Data.ByteString.Base64 as B64
-import qualified Data.ByteString.Lazy as LB
-import           Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NL
 import           Data.Maybe
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import           DockerLogin
-import           OktaClient
-import           STS
-import           Text.XML
-import           Text.XML.Lens
+import qualified Data.Text.IO as TIO
+import           OktaLogin
+import           System.Exit
 import           Types
 
-
-
 main:: IO ()
-main = runWithCommand runTopLevelCommand
+main = parseCLICommand >>= runTopLevelCommand
 
 
 -- | Run top-level command
 runTopLevelCommand :: Command -> IO ()
+
+
+-- | List configured AWS profiles
+runTopLevelCommand (ListProfiles confFilePath) = do
+  (allProfiles, defProf) <- listAppConfigProfiles confFilePath
+  envProf <- getEnvAWSProfile
+
+  forM_ allProfiles $ \p -> TIO.putStrLn $ unAwsProfile p
+  forM_ defProf $ \p -> TIO.putStrLn $ "\nYour configured default profile is " <> unAwsProfile p <> "."
+  forM_ envProf $ \p -> TIO.putStrLn $ "\nYour environment is configured with " <> unAwsProfile p <> ", it will override your config file defaults."
+
+  when ((null . catMaybes) [envProf, defProf]) $
+    TIO.putStrLn $ "\nNote that you can change your default AWS profile by exporting AWS_PROFILE environmental variable" <>
+                    " or adding '\"default\": true' property to your preferred AWS profile in the config file."
+
+  die ""
 
 
 -- | Initial (or incremental) config of the app
@@ -53,155 +52,5 @@ runTopLevelCommand (Configure ConfigArgs{..}) = do
   writeAppConfigFile confArgsConfFilePath newConf
 
 
--- | Login to AWS with Okta
-runTopLevelCommand (Login args) = flip runApp args $ do
-  cr <- getUserCredentials
-  _ <- createInitialOrgSessions >>= setSamlSession
-
-  -- First login, possibly ask user some questions
-  _ <- updateSamlSession (refreshSamlSession cr)
-
-  minSessionDurationSeconds <- (\configs -> minimum (ocSessionDurationSeconds <$> configs)) <$> getOktaAWSConfig
-  let sleepTime = minSessionDurationSeconds - 1 -- 1 sec before expiration
-
-  whileM_ keepReloading $ do
-    $(logDebug) $ "Sleeping for " <> tshow sleepTime <> " seconds ..."
-    liftIO $ threadDelay $ fromIntegral sleepTime * 1000000
-
-    uMfa <- usedMFA
-
-    doRefresh <- if uMfa
-                then ("y" ==) <$> askUser True "Refresh session? (y/n) >" -- if we get session from Okta first it may expire by the time user pays any attention to this, need to ask first
-                else return True -- probably on a trusted network, just try to refresh
-
-    unless doRefresh $ error "Session refresh cancelled, exiting ..."
-    useMFA False -- reset state, network may have switched by now
-    updateSamlSession (refreshSamlSession cr)
-
-
-refreshSamlSession :: UserCredentials
-                   -> SamlSession
-                   -> App SamlSession
-refreshSamlSession cr sess = do
-  $(logInfo) "Refreshing AWS session ..."
-
-  allUpdatedAccountSessions <- traverse (refreshAccountSession cr) sess
-
-  let allUpdatedAwsCreds = (\SamlAccountSession{..} -> (sasAwsProfile, sasAwsCredentials)) <$> allUpdatedAccountSessions
-      allUpdatedDockerAuths = concat (sasDockerAuths <$> allUpdatedAccountSessions)
-
-  $(logDebug) $ T.pack $ "Updating AWS creds to " <> show allUpdatedAwsCreds
-  updateAwsCreds allUpdatedAwsCreds
-
-  unless (null allUpdatedDockerAuths) $ do
-    $(logDebug) $ T.pack $ "Updating Docker auths to " <> show allUpdatedDockerAuths
-    dockerLogin allUpdatedDockerAuths
-
-  $(logInfo) "Refreshed AWS session."
-  return allUpdatedAccountSessions
-
-
-
-refreshAccountSession :: UserCredentials
-                      -> SamlAccountSession
-                      -> App SamlAccountSession
-refreshAccountSession uc sas@SamlAccountSession{..} = do
-
-  oktaOrg <- parseOktaOrg sasEmbedLink
-  errorOrRes <- oktaAuthenticate oktaOrg $ AuthRequestUserCredentials uc
-
-  res <- case errorOrRes
-           of Left e -> error $ "Unexpected Okta response: " <> show e <> " please check your credentials!"
-              Right r -> return r
-
-  -- May need to try MFA
-  sessionTok <- case res
-                  of AuthResponseSuccess st -> return st
-                     AuthResponseMFARequired st mfas -> askForMFA oktaOrg st mfas
-                     AuthResponseOther e -> error $ "Unexpected Okta response: " <> show e
-
-  saml <- getOktaAWSSaml sasEmbedLink sessionTok
-  samlRole <- case sasChosenSamlRole
-                of Just sr -> return sr
-                   Nothing -> chooseSamlRole (parseSamlAssertion saml)
-
-  (awsCreds, dockerAuths) <- awsAssumeRole sasECRLogin sasSessionDurationSeconds  saml samlRole
-
-  let updatedSession = sas { sasChosenSamlRole = Just samlRole
-                           , sasAwsCredentials = awsCreds
-                           , sasDockerAuths = dockerAuths }
-
-  return updatedSession
-
-
-askForMFA :: OktaOrg
-          -> StateToken
-          -> [MFAFactor]
-          -> App SessionToken
-askForMFA oOrg st mfas = do
-  -- Mark that we needed MFA in this session. When we keep reloading we need to wait until the user
-  -- is ready until acquiring state token. Otherwise it may expire by the time user reacts.
-  useMFA True
-
-  let totpMfas = findTotpFactors mfas
-
-  when (null totpMfas) $ error "Sorry, an MFA auth is required to continue and no TOTP factors were available. Please configure a TOTP device (e.g. a mobile Okta app) or re-try via VPN connection."
-
-  (fid, pc) <- do
-    MFAFactor{..} <- chooseOne $ NL.fromList $
-                        fmap (\(nc, f@MFAFactor{..}) -> nc mfaProvider f)
-                        (zip numericChoices totpMfas)
-    pc <- MFAPassCode <$> askUser True ("Please enter " <> unOktaOrg oOrg <> " " <> mfaProvider <> " MFA code> ")
-    return (mfaId, pc)
-
-
-  errorOrRes <- oktaMFAVerify oOrg $ AuthRequestMFATOTPVerify st fid pc
-
-  case errorOrRes
-    of Left e -> do _ <- $(logError) $ "Unexpected Okta response: " <> tshow e <> " please try again."
-                    askForMFA oOrg st mfas
-       Right r -> case r
-                    of AuthResponseSuccess s -> return s
-                       e                     -> error $ "Unexpected Okta response: " <> show e
-
-
-chooseSamlRole :: NonEmpty SamlRole
-               -> App SamlRole
-chooseSamlRole srs =
-  chooseOne $ fmap (\(nc, sr@SamlRole{..}) -> nc srRoleARN sr) (NL.zip (NL.fromList numericChoices) srs)
-
-
--- | Okta gives us a Base64 encoded XML doc with assertions, decode available roles.
--- https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language
-parseSamlAssertion :: SamlAssertion
-                   -> NonEmpty SamlRole
-parseSamlAssertion (SamlAssertion sa) =
-  let doc = parseLBS_ def ((LB.fromStrict . B64.decodeLenient . TE.encodeUtf8) sa)
-      roles = doc ^.. root . named "Response" ./
-                             named "Assertion" ./
-                             named "AttributeStatement" ./
-                             (named "Attribute" . attributeIs "Name" "https://aws.amazon.com/SAML/Attributes/Role") ./
-                             (named "AttributeValue" . text)
-
-      mkRole [pArn, rArn] = SamlRole rArn pArn
-      mkRole x = error $ "Couldn't parse SAML role ARNs from " <> show x
-
-      extractRoles = mkRole <$> fmap (T.splitOn ",") roles
-
-   in fromMaybe (error $ "Sorry, couldn't extract any role ARNs from " <> show doc) (NL.nonEmpty extractRoles)
-
-
--- | Init session data with some defaults and dummy values
-createInitialOrgSessions :: App [SamlAccountSession]
-createInitialOrgSessions = do
-  samlConfs <- getOktaAWSConfig
-  $(logInfo) $ "Using AWS profiles " <> tshow (unAwsProfile . ocAwsProfile <$> samlConfs)
-
-  let emptyCreds = SamlAWSCredentials "" "" ""
-
-      initialAccountSession OktaAWSConfig{..} =
-        SamlAccountSession ocEmbedLink (fromMaybe False ocECRLogin) ocSessionDurationSeconds ocAwsProfile Nothing emptyCreds []
-
-      initialAccountSessions = initialAccountSession <$> samlConfs
-
-  return $ NL.toList initialAccountSessions
+-- | Main top-level command
+runTopLevelCommand (Login args) = runApp oktaLogin args

--- a/src/OktaLogin.hs
+++ b/src/OktaLogin.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
+
+module OktaLogin (
+  oktaLogin
+) where
+
+
+import           AWSCredsFile
+import           App
+import           Control.Concurrent
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.Logger
+import           Control.Monad.Loops
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Lazy as LB
+import           Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NL
+import           Data.Maybe
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           DockerLogin
+import           OktaClient
+import           STS
+import           Text.XML
+import           Text.XML.Lens
+import           Types
+
+
+-- | Login to AWS with Okta
+--   Implementation of the main top level command (login to AWS through Okta).
+oktaLogin :: App ()
+oktaLogin = do
+  startedWithArgs <- getArgs
+  $(logDebugSH) startedWithArgs
+
+  cr <- getUserCredentials
+  _ <- createInitialOrgSessions >>= setSamlSession
+
+  -- First login, possibly ask user some questions
+  _ <- updateSamlSession (refreshSamlSession cr)
+
+  minSessionDurationSeconds <- (\configs -> minimum (ocSessionDurationSeconds <$> configs)) <$> getOktaAWSConfig
+  let sleepTime = minSessionDurationSeconds - 1 -- 1 sec before expiration
+
+  whileM_ keepReloading $ do
+    $(logDebug) $ "Sleeping for " <> tshow sleepTime <> " seconds ..."
+    liftIO $ threadDelay $ fromIntegral sleepTime * 1000000
+
+    uMfa <- usedMFA
+
+    doRefresh <- if uMfa
+                then ("y" ==) <$> askUser True "Refresh session? (y/n) >" -- if we get session from Okta first it may expire by the time user pays any attention to this, need to ask first
+                else return True -- probably on a trusted network, just try to refresh
+
+    unless doRefresh $ error "Session refresh cancelled, exiting ..."
+    useMFA False -- reset state, network may have switched by now
+    updateSamlSession (refreshSamlSession cr)
+
+
+-- | Refresh AWS (and possibly docker) auth sessions for all profiles listed on the command line
+refreshSamlSession :: UserCredentials
+                   -> SamlSession
+                   -> App SamlSession
+refreshSamlSession cr sess = do
+  $(logInfo) "Refreshing AWS session ..."
+
+  allUpdatedAccountSessions <- traverse (refreshAccountSession cr) sess
+
+  let allUpdatedAwsCreds = (\SamlAccountSession{..} -> (sasAwsProfile, sasAwsCredentials)) <$> allUpdatedAccountSessions
+      allUpdatedDockerAuths = concat (sasDockerAuths <$> allUpdatedAccountSessions)
+
+  $(logDebug) $ T.pack $ "Updating AWS creds to " <> show allUpdatedAwsCreds
+  updateAwsCreds allUpdatedAwsCreds
+
+  unless (null allUpdatedDockerAuths) $ do
+    $(logDebug) $ T.pack $ "Updating Docker auths to " <> show allUpdatedDockerAuths
+    dockerLogin allUpdatedDockerAuths
+
+  $(logInfo) "Refreshed AWS session."
+  return allUpdatedAccountSessions
+
+
+-- | Refresh AWS and possibly docker auths for a single AWS profile (usually associated with an account)
+refreshAccountSession :: UserCredentials
+                      -> SamlAccountSession
+                      -> App SamlAccountSession
+refreshAccountSession uc sas@SamlAccountSession{..} = do
+
+  oktaOrg <- parseOktaOrg sasEmbedLink
+  errorOrRes <- oktaAuthenticate oktaOrg $ AuthRequestUserCredentials uc
+
+  res <- case errorOrRes
+           of Left e -> error $ "Unexpected Okta response: " <> show e <> " please check your credentials!"
+              Right r -> return r
+
+  -- May need to try MFA
+  sessionTok <- case res
+                  of AuthResponseSuccess st -> return st
+                     AuthResponseMFARequired st mfas -> askForMFA oktaOrg st mfas
+                     AuthResponseOther e -> error $ "Unexpected Okta response: " <> show e
+
+  saml <- getOktaAWSSaml sasEmbedLink sessionTok
+  samlRole <- case sasChosenSamlRole
+                of Just sr -> return sr
+                   Nothing -> chooseSamlRole (parseSamlAssertion saml)
+
+  (awsCreds, dockerAuths) <- awsAssumeRole sasECRLogin sasSessionDurationSeconds  saml samlRole
+
+  let updatedSession = sas { sasChosenSamlRole = Just samlRole
+                           , sasAwsCredentials = awsCreds
+                           , sasDockerAuths = dockerAuths }
+
+  return updatedSession
+
+
+-- | Ask user to enter 2nd factor token if required
+askForMFA :: OktaOrg
+          -> StateToken
+          -> [MFAFactor]
+          -> App SessionToken
+askForMFA oOrg st mfas = do
+  -- Mark that we needed MFA in this session. When we keep reloading we need to wait until the user
+  -- is ready until acquiring state token. Otherwise it may expire by the time user reacts.
+  useMFA True
+
+  let totpMfas = findTotpFactors mfas
+
+  when (null totpMfas) $ error "Sorry, an MFA auth is required to continue and no TOTP factors were available. Please configure a TOTP device (e.g. a mobile Okta app) or re-try via VPN connection."
+
+  (fid, pc) <- do
+    MFAFactor{..} <- chooseOne $ NL.fromList $
+                        fmap (\(nc, f@MFAFactor{..}) -> nc mfaProvider f)
+                        (zip numericChoices totpMfas)
+    pc <- MFAPassCode <$> askUser True ("Please enter " <> unOktaOrg oOrg <> " " <> mfaProvider <> " MFA code> ")
+    return (mfaId, pc)
+
+
+  errorOrRes <- oktaMFAVerify oOrg $ AuthRequestMFATOTPVerify st fid pc
+
+  case errorOrRes
+    of Left e -> do _ <- $(logError) $ "Unexpected Okta response: " <> tshow e <> " please try again."
+                    askForMFA oOrg st mfas
+       Right r -> case r
+                    of AuthResponseSuccess s -> return s
+                       e                     -> error $ "Unexpected Okta response: " <> show e
+
+
+-- | Ask user to choose SAML role if more then one is available
+chooseSamlRole :: NonEmpty SamlRole
+               -> App SamlRole
+chooseSamlRole srs =
+  chooseOne $ fmap (\(nc, sr@SamlRole{..}) -> nc srRoleARN sr) (NL.zip (NL.fromList numericChoices) srs)
+
+
+-- | Okta gives us a Base64 encoded XML doc with assertions, decode available roles.
+-- https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language
+parseSamlAssertion :: SamlAssertion
+                   -> NonEmpty SamlRole
+parseSamlAssertion (SamlAssertion sa) =
+  let doc = parseLBS_ def ((LB.fromStrict . B64.decodeLenient . TE.encodeUtf8) sa)
+      roles = doc ^.. root . named "Response" ./
+                             named "Assertion" ./
+                             named "AttributeStatement" ./
+                             (named "Attribute" . attributeIs "Name" "https://aws.amazon.com/SAML/Attributes/Role") ./
+                             (named "AttributeValue" . text)
+
+      mkRole [pArn, rArn] = SamlRole rArn pArn
+      mkRole x = error $ "Couldn't parse SAML role ARNs from " <> show x
+
+      extractRoles = mkRole <$> fmap (T.splitOn ",") roles
+
+   in fromMaybe (error $ "Sorry, couldn't extract any role ARNs from " <> show doc) (NL.nonEmpty extractRoles)
+
+
+-- | Init session data with some defaults and dummy values
+createInitialOrgSessions :: App [SamlAccountSession]
+createInitialOrgSessions = do
+  samlConfs <- getOktaAWSConfig
+  $(logInfo) $ "Using AWS profiles " <> tshow (unAwsProfile . ocAwsProfile <$> samlConfs)
+
+  let emptyCreds = SamlAWSCredentials "" "" ""
+
+      initialAccountSession OktaAWSConfig{..} =
+        SamlAccountSession ocEmbedLink (fromMaybe False ocECRLogin) ocSessionDurationSeconds ocAwsProfile Nothing emptyCreds []
+
+      initialAccountSessions = initialAccountSession <$> samlConfs
+
+  return $ NL.toList initialAccountSessions


### PR DESCRIPTION
Fixed interpretation of conflicting CLI options, moved config-related options to a subcommand.
Also keeps main help output related to login functionality smaller.