### PR TITLE
Respect ecr CLI Arg

### DIFF
--- a/src/OktaLogin.hs
+++ b/src/OktaLogin.hs
@@ -114,7 +114,9 @@ refreshAccountSession uc mte sas@SamlAccountSession{..} = do
                 of Just sr -> return sr
                    Nothing -> chooseSamlRole (parseSamlAssertion saml)
 
-  (awsCreds, dockerAuths) <- awsAssumeRole sasECRLogin sasSessionDurationSeconds  saml samlRole
+  ecrLogin <- doECRLogin sas
+
+  (awsCreds, dockerAuths) <- awsAssumeRole ecrLogin sasSessionDurationSeconds  saml samlRole
 
   let updatedSession = sas { sasChosenSamlRole = Just samlRole
                            , sasAwsCredentials = awsCreds


### PR DESCRIPTION
The last released bumped stackage's resolver version and there've been a change of behaviour in one of the dependencies, `aeson-casing`. A [PR](https://github.com/AndrewRademacher/aeson-casing/pull/5) is opened to bring the old behaviour back  but in the process of debugging the issue I realised that, as far as I can tell, the `--ecr` flag is never used to override the values present in the config file. This fixes that issue.